### PR TITLE
fix: use the `ip` command

### DIFF
--- a/bin/detect_ips.sh
+++ b/bin/detect_ips.sh
@@ -12,53 +12,50 @@ ip2int() { local _a=(${1//./ }) ; printf ${2+-v} $2 "%u" $(( _a<<24 |
                   ${_a[1]} << 16 | ${_a[2]} << 8 | ${_a[3]} )) ;}
 
 case "$(uname -s)" in
-    Darwin*)  runOnMac=true  ;;
-    *)        runOnMac=false ;;
-esac
+    Darwin*)
+        while IFS=$' :\t\r\n' read a b c d; do
+            case $a in
+                gateway )    gWay=$b  ;;
+                interface )  iFace=$b ;;
+            esac
+        done < <(/sbin/route -n get 0.0.0.0/0)
+        ip2int $gWay gw
+        
+        while read lhs rhs; do
+            [ "$lhs" ] && {
+                [ -z "${lhs#*:}" ] && iface=${lhs%:}
+                [ "$lhs" = "inet" ] && [ "$iface" = "$iFace" ] && {
+                    mask=${rhs#*netmask }
+                    mask=${mask%% *}
+                    [ "$mask" ] && [ -z "${mask%0x*}" ] &&
+                        printf -v mask %u $mask ||
+                        ip2int $mask mask
+                    ip2int ${rhs%% *} ip
+                    (( ( ip & mask ) == ( gw & mask ) )) &&
+                        int2ip $ip myIp && int2ip $mask netMask
+                }
+            }
+        done < <(/sbin/ifconfig)
+    ;;
+    *)
+        while IFS=$' :\t\r\n' read a b c d; do
+            [ "$a" = "0.0.0.0" ] && [ "$c" = "$a" ] && iFace=${d##* } gWay=$b
+        done < <(/sbin/route -n 2>&1)
+        ip2int $gWay gw
 
-if $runOnMac; then
-    while IFS=$' :\t\r\n' read a b c d; do
-        case $a in
-            gateway )    gWay=$b  ;;
-            interface )  iFace=$b ;;
-        esac
-    done < <(/sbin/route -n get 0.0.0.0/0)
-    ip2int $gWay gw
-
-    while read lhs rhs; do
-        [ "$lhs" ] && {
-            [ -z "${lhs#*:}" ] && iface=${lhs%:}
-            [ "$lhs" = "inet" ] && [ "$iface" = "$iFace" ] && {
-                mask=${rhs#*netmask }
-                mask=${mask%% *}
-                [ "$mask" ] && [ -z "${mask%0x*}" ] &&
-                    printf -v mask %u $mask ||
-                    ip2int $mask mask
-                ip2int ${rhs%% *} ip
+        while IFS=$' :\t\r\n' read iface state rhs; do
+            [ "$iface" = "$iFace" ] && {
+                ip2int "$(echo $rhs | cut -d '/' -f1)" ip
+                while IFS=$' :\t\r\n' read before netmask after; do
+                    mask=$netmask
+                done < <(/usr/bin/ipcalc -n -b $rhs | grep Netmask)
+                ip2int $mask mask
                 (( ( ip & mask ) == ( gw & mask ) )) &&
                     int2ip $ip myIp && int2ip $mask netMask
             }
-        }
-    done < <(/sbin/ifconfig)
-else
-    while IFS=$' :\t\r\n' read a b c d e rest; do
-        gWay=$c
-        iFace=$e
-    done < <(ip -4 -c=never route show default)
-    ip2int $gWay gw
-
-    while IFS=$' :\t\r\n' read iface state rhs; do
-        [ "$iface" = "$iFace" ] && {
-            ip2int "$(echo $rhs | cut -d '/' -f1)" ip
-            while IFS=$' :\t\r\n' read before netmask after; do
-                mask=$netmask
-            done < <(/usr/bin/ipcalc -n -b $rhs | grep Netmask)
-            ip2int $mask mask
-            (( ( ip & mask ) == ( gw & mask ) )) &&
-                int2ip $ip myIp && int2ip $mask netMask
-        }
-    done < <(ip -4 -c=never -br addr)
-fi
+        done < <(ip -4 -c=never -br addr)
+    ;;
+esac
 
 echo "KADCAST_PUBLIC_ADDRESS=$PUBLIC_IP:9000"
 if [ -z "$myIp" ]; then

--- a/bin/detect_ips.sh
+++ b/bin/detect_ips.sh
@@ -57,7 +57,7 @@ else
             (( ( ip & mask ) == ( gw & mask ) )) &&
                 int2ip $ip myIp && int2ip $mask netMask
         }
-    done < <(ip -4 -br addr)
+    done < <(ip -4 -c=never -br addr)
 fi
 
 echo "KADCAST_PUBLIC_ADDRESS=$PUBLIC_IP:9000"

--- a/bin/detect_ips.sh
+++ b/bin/detect_ips.sh
@@ -6,27 +6,25 @@ if [ -z "$PUBLIC_IP" ]; then
     PUBLIC_IP=`dig -4 TXT +short o-o.myaddr.l.google.com @ns1.google.com | sed 's|"||g'`
 fi
 
-runOnMac=false
 int2ip() { printf ${2+-v} $2 "%d.%d.%d.%d" \
         $(($1>>24)) $(($1>>16&255)) $(($1>>8&255)) $(($1&255)) ;}
 ip2int() { local _a=(${1//./ }) ; printf ${2+-v} $2 "%u" $(( _a<<24 |
                   ${_a[1]} << 16 | ${_a[2]} << 8 | ${_a[3]} )) ;}
 
-get_ip() {
-    while IFS=$' :\t\r\n' read iface state rhs; do
-        [ "$iface" = "$iFace" ] && {
-            ip2int "$(echo $rhs | cut -d '/' -f1)" ip
-            while IFS=$' :\t\r\n' read before netmask after; do
-                mask=$netmask
-            done < <(/usr/bin/ipcalc -n -b $rhs | grep Netmask)
-            ip2int $mask mask
-            (( ( ip & mask ) == ( gw & mask ) )) &&
-                int2ip $ip myIp && int2ip $mask netMask
-        }
-    done < <(ip -4 -br addr)
-}
+case "$(uname -s)" in
+    Darwin*)  runOnMac=true  ;;
+    *)        runOnMac=false ;;
+esac
 
-get_ip_macos() {
+if $runOnMac; then
+    while IFS=$' :\t\r\n' read a b c d; do
+        case $a in
+            gateway )    gWay=$b  ;;
+            interface )  iFace=$b ;;
+        esac
+    done < <(/sbin/route -n get 0.0.0.0/0)
+    ip2int $gWay gw
+
     while read lhs rhs; do
         [ "$lhs" ] && {
             [ -z "${lhs#*:}" ] && iface=${lhs%:}
@@ -42,21 +40,25 @@ get_ip_macos() {
             }
         }
     done < <(/sbin/ifconfig)
-}
+else
+    while IFS=$' :\t\r\n' read a b c d e rest; do
+        gWay=$c
+        iFace=$e
+    done < <(ip -4 -c=never route show default)
+    ip2int $gWay gw
 
-while IFS=$' :\t\r\n' read a b c d; do
-    [ "$a" = "usage" ] && [ "$b" = "route" ] && runOnMac=true
-    if $runOnMac; then
-        case $a in
-            gateway )    gWay=$b  ;;
-            interface )  iFace=$b ;;
-        esac
-    else
-        [ "$a" = "0.0.0.0" ] && [ "$c" = "$a" ] && iFace=${d##* } gWay=$b
-    fi
-done < <(/sbin/route -n 2>&1 || /sbin/route -n get 0.0.0.0/0)
-ip2int $gWay gw
-[ $runOnMac ] && get_ip_macos || get_ip
+    while IFS=$' :\t\r\n' read iface state rhs; do
+        [ "$iface" = "$iFace" ] && {
+            ip2int "$(echo $rhs | cut -d '/' -f1)" ip
+            while IFS=$' :\t\r\n' read before netmask after; do
+                mask=$netmask
+            done < <(/usr/bin/ipcalc -n -b $rhs | grep Netmask)
+            ip2int $mask mask
+            (( ( ip & mask ) == ( gw & mask ) )) &&
+                int2ip $ip myIp && int2ip $mask netMask
+        }
+    done < <(ip -4 -br addr)
+fi
 
 echo "KADCAST_PUBLIC_ADDRESS=$PUBLIC_IP:9000"
 if [ -z "$myIp" ]; then

--- a/bin/detect_ips.sh
+++ b/bin/detect_ips.sh
@@ -11,9 +11,42 @@ int2ip() { printf ${2+-v} $2 "%d.%d.%d.%d" \
         $(($1>>24)) $(($1>>16&255)) $(($1>>8&255)) $(($1&255)) ;}
 ip2int() { local _a=(${1//./ }) ; printf ${2+-v} $2 "%u" $(( _a<<24 |
                   ${_a[1]} << 16 | ${_a[2]} << 8 | ${_a[3]} )) ;}
+
+get_ip() {
+    while IFS=$' :\t\r\n' read iface state rhs; do
+        [ "$iface" = "$iFace" ] && {
+            ip2int "$(echo $rhs | cut -d '/' -f1)" ip
+            while IFS=$' :\t\r\n' read before netmask after; do
+                mask=$netmask
+            done < <(/usr/bin/ipcalc -n -b $rhs | grep Netmask)
+            ip2int $mask mask
+            (( ( ip & mask ) == ( gw & mask ) )) &&
+                int2ip $ip myIp && int2ip $mask netMask
+        }
+    done < <(ip -4 -br addr)
+}
+
+get_ip_macos() {
+    while read lhs rhs; do
+        [ "$lhs" ] && {
+            [ -z "${lhs#*:}" ] && iface=${lhs%:}
+            [ "$lhs" = "inet" ] && [ "$iface" = "$iFace" ] && {
+                mask=${rhs#*netmask }
+                mask=${mask%% *}
+                [ "$mask" ] && [ -z "${mask%0x*}" ] &&
+                    printf -v mask %u $mask ||
+                    ip2int $mask mask
+                ip2int ${rhs%% *} ip
+                (( ( ip & mask ) == ( gw & mask ) )) &&
+                    int2ip $ip myIp && int2ip $mask netMask
+            }
+        }
+    done < <(/sbin/ifconfig)
+}
+
 while IFS=$' :\t\r\n' read a b c d; do
     [ "$a" = "usage" ] && [ "$b" = "route" ] && runOnMac=true
-    if $runOnMac ;then
+    if $runOnMac; then
         case $a in
             gateway )    gWay=$b  ;;
             interface )  iFace=$b ;;
@@ -23,21 +56,7 @@ while IFS=$' :\t\r\n' read a b c d; do
     fi
 done < <(/sbin/route -n 2>&1 || /sbin/route -n get 0.0.0.0/0)
 ip2int $gWay gw
-while read lhs rhs; do
-    [ "$lhs" ] && {
-        [ -z "${lhs#*:}" ] && iface=${lhs%:}
-        [ "$lhs" = "inet" ] && [ "$iface" = "$iFace" ] && {
-            mask=${rhs#*netmask }
-            mask=${mask%% *}
-            [ "$mask" ] && [ -z "${mask%0x*}" ] &&
-                printf -v mask %u $mask ||
-                ip2int $mask mask
-            ip2int ${rhs%% *} ip
-            (( ( ip & mask ) == ( gw & mask ) )) &&
-                int2ip $ip myIp && int2ip $mask netMask
-        }
-    }
-done < <(/sbin/ifconfig)
+[ $runOnMac ] && get_ip_macos || get_ip
 
 echo "KADCAST_PUBLIC_ADDRESS=$PUBLIC_IP:9000"
 if [ -z "$myIp" ]; then

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -84,7 +84,6 @@ check_installed unzip unzip
 check_installed curl curl
 check_installed ipcalc ipcalc
 check_installed jq jq
-check_installed route net-tools
 check_installed logrotate logrotate
 check_installed dig dnsutils
 

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -84,6 +84,7 @@ check_installed unzip unzip
 check_installed curl curl
 check_installed ipcalc ipcalc
 check_installed jq jq
+check_installed route net-tools
 check_installed logrotate logrotate
 check_installed dig dnsutils
 

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -82,6 +82,7 @@ echo "Checking prerequisites"
 update_pkg_database
 check_installed unzip unzip
 check_installed curl curl
+check_installed ipcalc ipcalc
 check_installed jq jq
 check_installed route net-tools
 check_installed logrotate logrotate


### PR DESCRIPTION
- fixes #41
- fix: remove usage of deprecated `ifconfig`

Now using `ip` (which is available since at least [2011](https://dougvitale.wordpress.com/2011/12/21/deprecated-linux-networking-commands-and-their-replacements/)).

- fix: stick with `ip` for the route check

The new code is more readable and contains less lines actually. But I needed to keep the macOS compatibility, so that's why the patch is more important.

If the macOs support can be dropped, then I could simplify more, LMK.