### PR TITLE
fix: Linux distribution discovering

### DIFF
--- a/node-installer.sh
+++ b/node-installer.sh
@@ -8,7 +8,7 @@ get_linux_distro() {
     if [ -f /etc/os-release ]; then 
         # systemd users should have os-release available
         . /etc/os-release
-        distro=$(echo "$NAME" | tr '[:upper:]' '[:lower:]')
+        distro=$(echo "$NAME" | cut -d' ' -f1 | tr '[:upper:]' '[:lower:]')
     elif type lsb_release >/dev/null 2>&1; then
         distro=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
     else


### PR DESCRIPTION
On my computer, I have:

```bash
$ echo "$NAME"                             
Debian GNU/Linux
```

So it is not seen as a compatible machine.