### PR TITLE
Add cloud-init example to node-installer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig  https://editorconfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# All files
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# yml & yaml files
+[*.{yml,yaml}]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false
+
+# Shell files
+[*.sh]
+end_of_line = lf

--- a/cloud-init/README.md
+++ b/cloud-init/README.md
@@ -1,0 +1,43 @@
+# Cloud Init Usage
+
+> The current cloud-init is tailored towards Ubuntu
+
+## Testing cloud-init locally for free
+
+### 1. Install Multipass
+
+Multipass is able to provide Ubuntu VMs that can be initialized with cloud-init to simulate cloud deployments locally. It is available for Linux, Windows and MacOS.
+
+Additional resources:
+- https://multipass.run/install
+- https://multipass.run/docs/tutorial
+
+### 2. Run
+
+```bash
+multipass launch -n dusknode --cloud-init dusknode.yaml
+```
+
+This will create a VM with the latest Ubuntu LTS image and apply the `dusknode.yml` cloud-init configuration.
+
+This will create a user "dusk" along with some other configuation and the execution of the `node-installer.sh` script. Ensure your SSH public key is added to the ssh_authorized_keys field in the YAML configuration before applying it.
+
+### 3. Use
+
+#### Check out existing VMs
+```bash
+multipass list
+```
+
+#### Open shell of dusknode VM
+```bash 
+multipass shell dusknode
+```
+
+You can either use the Multipass GUI or use the CLI. Running `sudo su dusk` in the respective VM, will log you in as the dusk user who has the node installed.
+
+#### Restart multipass on linux
+
+```bash
+sudo snap restart multipass.multipassd
+```

--- a/cloud-init/dusknode.yaml
+++ b/cloud-init/dusknode.yaml
@@ -1,0 +1,49 @@
+#cloud-config
+# written for:
+# - Ubuntu 24.04 LTS
+users:
+  - name: dusk
+    gecos: Dusk Node User
+    groups: users, admin
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    lock_passwd: true # Lock the password to prevent login
+    ssh_authorized_keys:
+      - <YOUR_SSH_PUBLIC_KEY> # Add your SSH public key here
+disable_root: true
+ssh_pwauth: false
+ssh_deletekeys: true
+packages:
+  - fail2ban
+  - ufw
+  #- unattended-upgrades
+package_update: true
+package_upgrade: true
+package_reboot_if_required: true
+runcmd:
+  - printf "[sshd]\nenabled = true\nbanaction = iptables-multiport" > /etc/fail2ban/jail.local
+  - systemctl enable fail2ban
+  - ufw allow ssh comment "ssh" # SSH
+  - ufw allow 8080/tcp comment "Node HTTP listener" # HTTP listener
+  - ufw allow 9000/udp comment "Kadcast" # Kadcast P2P
+  - ufw --force enable
+  - curl --proto '=https' --tlsv1.2 -sSfL https://github.com/dusk-network/node-installer/releases/latest/download/node-installer.sh | sudo sh # Download latest Dusk node installer release and run it
+  - echo "Cloud-init has finished" > /home/dusk/setup.log
+  - chown dusk:dusk /home/dusk/setup.log
+  - chmod 600 /home/dusk/setup.log
+  - sshd -t >> /home/dusk/setup.log # Test the SSH configuration & log the output
+  - echo "SSH service has been restarted" >> /home/dusk/setup.log
+  - ufw status >> /home/dusk/setup.log # Check the status of the firewall & log the output
+  - echo "Firewall status has been checked" >> /home/dusk/setup.log
+  - fail2ban-client status sshd >> /home/dusk/setup.log # Check the status of the fail2ban service & log the output
+  - echo "Fail2ban status has been checked" >> /home/dusk/setup.log
+  - ruskquery version >> /home/dusk/setup.log # Check the version of the dusk node & log the output
+  - echo "Dusk node version has been checked" >> /home/dusk/setup.log
+  - echo "Cloud-init has finished" >> /home/dusk/setup.log
+  - touch /tmp/cloud-init-finished
+power_state: # Reboot the system to apply updates and changes
+  delay: now
+  mode: reboot
+  message: Rebooting the system to apply updates and changes
+  timeout: 2
+  condition: test -f /tmp/cloud-init-finished

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -5,7 +5,7 @@ os=$(uname -s)
 distro="unknown"
 
 get_linux_distro() {
-    if [ -f /etc/os-release ]; then 
+    if [ -f /etc/os-release ]; then
         # systemd users should have os-release available
         . /etc/os-release
         distro=$(echo "$NAME" | cut -d' ' -f1 | tr '[:upper:]' '[:lower:]')
@@ -31,6 +31,13 @@ esac
 # Check for Debian or Ubuntu on x86_64 architecture
 if [ "$distro" != "debian" ] && [ "$distro" != "ubuntu" ] || [ "$arch" != "x86_64" ]; then
     echo "Unsupported OS or architecture. This installer only supports Debian/Ubuntu-based systems with the x86_64 architecture."
+    exit 1
+fi
+
+# Check for OpenSSL 3 or higher
+if ! command -v openssl >/dev/null 2>&1 || [ "$(openssl version | awk '{print $2}' | cut -d. -f1)" -lt 3 ]; then
+    echo "The required OpenSSL version is not available. Please install OpenSSL 3 or higher"
+    echo "You likely need to upgrade your OS or install a newer OS"
     exit 1
 fi
 
@@ -258,7 +265,7 @@ echo "service rusk start"
 echo
 echo "To run the Rusk wallet:"
 echo "rusk-wallet"
-echo 
+echo
 echo "To check the logs:"
 echo "tail -F /var/log/rusk.log"
 echo


### PR DESCRIPTION
Cloud-init configuration:
Added a new cloud-init configuration file for setting up a Dusk node on Ubuntu 24.04 LTS. This includes user creation, package installations, firewall rules, and commands to run the Dusk node installer.

Installation script:
Added a check to ensure that OpenSSL version 3 or higher is installed before proceeding with the installation.