### PR TITLE
feat: allow to tweak the endpoint API in `ruskquery`

### DIFF
--- a/bin/ruskquery
+++ b/bin/ruskquery
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-API_ENDPOINT="http://127.0.0.1:8080"
+API_ENDPOINT="${API_ENDPOINT:-http://127.0.0.1:8080}"
 RUSK_VERSION="1.0.0-rc.0"
 CONTENT_TYPE="application/json"
 INSTALLER_VERSION="v0.5.1"


### PR DESCRIPTION
I was wondering if such a change would be interesting to share.

I wanted to use `ruskquery` on another endpoint (mainly `https://nodes.dusk.network`) in order to simplify my command aliases.

As example, I would love to be able to replace this:

```bash
curl -s https://nodes.dusk.network/02/Chain --data-raw '"'"'{"topic":"gql","data":"query{block(height:-1){header{height}}}"}'"'"' | jq .block.header.height
```

with that:

```bash
API_ENDPOINT='https://nodes.dusk.network' ruskquery block-height
```