### PR TITLE
fix: replace usage of outdated `ifconfig` with `ip`

### DIFF
--- a/bin/detect_ips.sh
+++ b/bin/detect_ips.sh
@@ -12,38 +12,21 @@ if [[ -z "$PUBLIC_IP" || ! "$PUBLIC_IP" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; 
     exit 1
 fi
 
-runOnMac=false
 int2ip() { printf ${2+-v} $2 "%d.%d.%d.%d" \
-        $(($1>>24)) $(($1>>16&255)) $(($1>>8&255)) $(($1&255)) ;}
-ip2int() { local _a=(${1//./ }) ; printf ${2+-v} $2 "%u" $(( _a<<24 |
-                  ${_a[1]} << 16 | ${_a[2]} << 8 | ${_a[3]} )) ;}
+    $(($1>>24)) $(($1>>16&255)) $(($1>>8&255)) $(($1&255)) ;}
+ip2int() { local _a=(${1//./ }) ; printf ${2+-v} $2 "%u" \
+    $(( _a<<24 | ${_a[1]} << 16 | ${_a[2]} << 8 | ${_a[3]} )) ;}
+
 while IFS=$' :\t\r\n' read a b c d; do
-    [ "$a" = "usage" ] && [ "$b" = "route" ] && runOnMac=true
-    if $runOnMac ;then
-        case $a in
-            gateway )    gWay=$b  ;;
-            interface )  iFace=$b ;;
-        esac
-    else
-        [ "$a" = "0.0.0.0" ] && [ "$c" = "$a" ] && iFace=${d##* } gWay=$b
-    fi
-done < <(/sbin/route -n 2>&1 || /sbin/route -n get 0.0.0.0/0)
+    [ "$a" = "0.0.0.0" ] && [ "$c" = "$a" ] && iFace=${d##* } gWay=$b
+done < <(/sbin/route -n 2>&1)
 ip2int $gWay gw
-while read lhs rhs; do
-    [ "$lhs" ] && {
-        [ -z "${lhs#*:}" ] && iface=${lhs%:}
-        [ "$lhs" = "inet" ] && [ "$iface" = "$iFace" ] && {
-            mask=${rhs#*netmask }
-            mask=${mask%% *}
-            [ "$mask" ] && [ -z "${mask%0x*}" ] &&
-                printf -v mask %u $mask ||
-                ip2int $mask mask
-            ip2int ${rhs%% *} ip
-            (( ( ip & mask ) == ( gw & mask ) )) &&
-                int2ip $ip myIp && int2ip $mask netMask
-        }
-    }
-done < <(/sbin/ifconfig)
+local_ip="$($(which ip) -j -4 -br addr | jq ". | map(select(.ifname == \"$iFace\")) | .[].addr_info.[0].local" | cut -d'"' -f2)"
+ip2int $local_ip ip
+mask="$($(which ipcalc) -n -b $local_ip | grep Netmask | awk '{print $2}')"
+ip2int $mask mask
+(( ( ip & mask ) == ( gw & mask ) )) &&
+    int2ip $ip myIp && int2ip $mask netMask
 
 echo "KADCAST_PUBLIC_ADDRESS=$PUBLIC_IP:9000"
 if [ -z "$myIp" ]; then
@@ -51,4 +34,3 @@ if [ -z "$myIp" ]; then
 else
     echo "KADCAST_LISTEN_ADDRESS=$myIp:9000"
 fi
-

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -189,6 +189,7 @@ update_pkg_database
 check_installed unzip unzip
 check_installed curl curl
 check_installed route net-tools
+check_installed ipcalc ipcalc
 check_installed jq jq
 check_installed logrotate logrotate
 check_installed dig dnsutils


### PR DESCRIPTION
Fixes #41.

Changes in `int2ip()`, and `ip2int`, are cosmetic only.

Tested with success on my local machine + Vultr.