### PR TITLE
Simplify IP detect & fix issue #157

### DIFF
--- a/bin/detect_ips.sh
+++ b/bin/detect_ips.sh
@@ -1,36 +1,25 @@
 #!/bin/bash
+set -euo pipefail
 
 # Fetch IPv4 WAN address using ifconfig.me, fallback to ipinfo.io
-PUBLIC_IP=$(curl -4 -s https://ifconfig.me)
-if [ -z "$PUBLIC_IP" ]; then
-    PUBLIC_IP=$(curl -4 -s https://ipinfo.io/ip)
-fi
+PUBLIC_IP=$(curl -4 -s https://ifconfig.me || curl -4 -s https://ipinfo.io/ip || true)
 
 # Validate IPv4 address
-if [[ -z "$PUBLIC_IP" || ! "$PUBLIC_IP" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: Unable to retrieve a valid WAN IPv4 address"
+if [[ ! "$PUBLIC_IP" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Unable to retrieve a valid WAN IPv4 address" >&2
     exit 1
 fi
 
-int2ip() { printf ${2+-v} $2 "%d.%d.%d.%d" \
-    $(($1>>24)) $(($1>>16&255)) $(($1>>8&255)) $(($1&255)) ;}
-ip2int() { local _a=(${1//./ }) ; printf ${2+-v} $2 "%u" \
-    $(( _a<<24 | ${_a[1]} << 16 | ${_a[2]} << 8 | ${_a[3]} )) ;}
+# Detect the local IP via route table (for machines behind NAT or in internal networks)
+# We query 1.1.1.1 here to get the primary outbound interface
+LOCAL_IP=$(ip route get 1.1.1.1 | awk '{print $7; exit}')
 
-while IFS=$' :\t\r\n' read a b c d; do
-    [ "$a" = "0.0.0.0" ] && [ "$c" = "$a" ] && iFace=${d##* } gWay=$b
-done < <(/sbin/route -n 2>&1)
-ip2int $gWay gw
-localIp="$($(which ip) -j -4 -br addr | jq -r ". | map(select(.ifname == \"$iFace\")) | .[].addr_info.[0].local")"
-ip2int $localIp ip
-mask="$($(which ipcalc) -n -b $localIp | grep Netmask | awk '{print $2}')"
-ip2int $mask mask
-(( ( ip & mask ) == ( gw & mask ) )) &&
-    int2ip $ip myIp && int2ip $mask netMask
-
-echo "KADCAST_PUBLIC_ADDRESS=$PUBLIC_IP:9000"
-if [ -z "$myIp" ]; then
-    echo "KADCAST_LISTEN_ADDRESS=$PUBLIC_IP:9000"
-else
-    echo "KADCAST_LISTEN_ADDRESS=$myIp:9000"
+# Validate Local IPv4 address
+if [[ ! "$LOCAL_IP" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Unable to retrieve a valid local IPv4 address" >&2
+    exit 1
 fi
+
+# Output the KADCAST addresses
+echo "KADCAST_PUBLIC_ADDRESS=${PUBLIC_IP}:9000"
+echo "KADCAST_LISTEN_ADDRESS=${LOCAL_IP}:9000"


### PR DESCRIPTION
Resolves #157 

After extensive testing on multiple different Ubuntu 24.04.2 instances, it was unclear what causes the system differences. Even when the packages are aligned.

As a solution, I've opted to fallback to the simplified IP detection script we had before, but with slight modifications. The script lets go of legacy IP detection commands and uses `ip route get` to retrieve the outbound interface and local IP.

This variant was tested to work correctly on multiple Ubuntu 24.04.2 instances that did show different outputs with the old script.

@Neotamandua @herr-seppia I would appreciate it if you can verify if this works correctly on your ends too, thanks.