### PR TITLE
Update mainnet Rusk to 1.6.1

### DIFF
--- a/bin/ruskquery
+++ b/bin/ruskquery
@@ -3,7 +3,7 @@
 API_ENDPOINT="${API_ENDPOINT:-http://127.0.0.1:8080}"
 RUSK_VERSION="1.0.0"
 CONTENT_TYPE="application/json"
-INSTALLER_VERSION="v0.5.16"
+INSTALLER_VERSION="v0.5.18"
 
 show_help() {
     echo "Dusk Query Tool"

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -156,7 +156,7 @@ chown -R "$CURRENT_USER:dusk" "$CURRENT_HOME/.dusk"
 chmod -R 770 "$CURRENT_HOME/.dusk"
 
 # Download and extract installer files
-INSTALLER_URL="https://github.com/dusk-network/node-installer/archive/refs/tags/v0.5.18.tar.gz"
+INSTALLER_URL="https://github.com/dusk-network/node-installer/tarball/main"
 echo "Downloading installer package for additional scripts and configurations"
 curl -so /opt/dusk/installer/installer.tar.gz -L "$INSTALLER_URL"
 tar xf /opt/dusk/installer/installer.tar.gz --strip-components 1 --directory /opt/dusk/installer

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -9,7 +9,7 @@ echo "Home directory: $CURRENT_HOME"
 declare -A VERSIONS
 # Define versions per network, per component
 VERSIONS=(
-    ["mainnet-rusk"]="1.6.0"
+    ["mainnet-rusk"]="1.6.1"
     ["mainnet-rusk-wallet"]="0.3.0"
     ["testnet-rusk"]="1.7.0-rc.0"
     ["testnet-rusk-wallet"]="0.4.0"
@@ -156,7 +156,7 @@ chown -R "$CURRENT_USER:dusk" "$CURRENT_HOME/.dusk"
 chmod -R 770 "$CURRENT_HOME/.dusk"
 
 # Download and extract installer files
-INSTALLER_URL="https://github.com/dusk-network/node-installer/tarball/main"
+INSTALLER_URL="https://github.com/dusk-network/node-installer/archive/refs/tags/v0.5.18.tar.gz"
 echo "Downloading installer package for additional scripts and configurations"
 curl -so /opt/dusk/installer/installer.tar.gz -L "$INSTALLER_URL"
 tar xf /opt/dusk/installer/installer.tar.gz --strip-components 1 --directory /opt/dusk/installer


### PR DESCRIPTION
## Summary
- update mainnet Rusk from `1.6.0` to `1.6.1`
- update `ruskquery` installer version metadata to `v0.5.18`
- keep the installer URL reset to `main` after tagging, matching the existing release branch pattern

## Validation
- installed the draft release asset on a fresh Ubuntu 24.04 DigitalOcean droplet
- verified the installer downloaded `dusk-rusk 1.6.1` and `rusk-wallet 0.3.0`
- ran `download_state` successfully with latest mainnet state `4247882`
- followed the printed launch prerequisites: `rusk-wallet restore`, `rusk-wallet export -d /opt/dusk/conf -n consensus.keys`, and `sh /opt/dusk/bin/setup_consensus_pwd.sh`
- started `rusk.service` successfully and observed accepted/finalized mainnet blocks
- verified the corrected tag includes `INSTALLER_VERSION="v0.5.18"` in `bin/ruskquery`