### PR TITLE
Support testnet in download_state

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,12 +304,21 @@ ruskquery block-height
 To significantly reduce the time required to sync your node to the latest
 published state, you can use the `download_state` command. This command stops
 your node and replaces its current state with the latest published state from
-one of Dusk's archival nodes. Currently this is only available for mainnet.
+one of Dusk's archival nodes. The command automatically uses the archival
+endpoint for the network installed on the node by reading
+`/opt/dusk/conf/rusk.toml`, including mainnet and Nocturne testnet. If needed,
+you can override the detected network explicitly.
 
 To see the available published states, run:
 
 ```sh
 download_state --list
+```
+
+To override the detected network explicitly, run:
+
+```sh
+download_state --network testnet --list
 ```
 
 ### Using the Fast Sync Command
@@ -328,6 +337,11 @@ download_state --list
    need to pass the block height of the state you want to sync up with.
    ```sh
    download_state 369876
+   ```
+
+   If needed, you can also override the detected network while downloading:
+   ```sh
+   download_state --network testnet 369876
    ```
 
    Follow the prompts to confirm the operation.

--- a/bin/download_state.sh
+++ b/bin/download_state.sh
@@ -1,10 +1,88 @@
 #!/bin/bash
 set -e
 
-STATE_LIST_URL="https://nodes.dusk.network/state/list"
+RUSK_CONFIG_FILE="/opt/dusk/conf/rusk.toml"
+NETWORK=""
+LIST_STATES=0
+STATE_NUMBER=""
+
+usage() {
+  echo "Usage: $0 [--network mainnet|testnet] [--list] [state_number]"
+}
+
+detect_network() {
+  if [ -f "$RUSK_CONFIG_FILE" ]; then
+    case "$(grep -E "^kadcast_id" "$RUSK_CONFIG_FILE" | head -n 1 | awk -F= '{print $2}' | tr -d "[:space:]")" in
+      0x1)
+        printf '%s\n' "mainnet"
+        return 0
+        ;;
+      0x2)
+        printf '%s\n' "testnet"
+        return 0
+        ;;
+    esac
+  fi
+
+  return 1
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --network)
+      if [[ -z "$2" || "$2" == --* ]]; then
+        echo "Error: --network requires a value."
+        usage
+        exit 1
+      fi
+      NETWORK="$2"
+      shift 2
+      ;;
+    --list)
+      LIST_STATES=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "$STATE_NUMBER" ]]; then
+        echo "Error: Unexpected argument '$1'."
+        usage
+        exit 1
+      fi
+      STATE_NUMBER="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$NETWORK" ]]; then
+  if ! NETWORK=$(detect_network); then
+    echo "Error: Failed to detect network from $RUSK_CONFIG_FILE. Use --network mainnet|testnet."
+    exit 1
+  fi
+fi
+
+case "$NETWORK" in
+  mainnet)
+    STATE_BASE_URL="https://nodes.dusk.network/state"
+    ;;
+  testnet)
+    STATE_BASE_URL="https://testnet.nodes.dusk.network/state"
+    ;;
+  *)
+    echo "Error: Unsupported network '$NETWORK'."
+    exit 1
+    ;;
+esac
+
+STATE_LIST_URL="$STATE_BASE_URL/list"
 
 # Function to display a warning message
 display_warning() {
+  echo "Selected network: $NETWORK"
   echo "WARNING: This operation will STOP your node and REPLACE the current state with a new one."
   
   while : ; do
@@ -57,15 +135,14 @@ get_latest_state() {
   curl -f -L -s "$STATE_LIST_URL" | tail -n 1
 }
 
-# Check if an argument is provided, otherwise use the fallback value (348211)
-if [ "$1" = "--list" ]; then
+if [[ "$LIST_STATES" == "1" ]]; then
   # List all possible states
   list_states
   exit 0
-elif [ -n "$1" ]; then
+elif [[ -n "$STATE_NUMBER" ]]; then
   # User provided a specific state, check if it exists
-  state_number=$1
-  state_exists "$1"
+  state_number=$STATE_NUMBER
+  state_exists "$STATE_NUMBER"
 else
   # No argument provided, use the latest state
   state_number=$(get_latest_state)
@@ -75,7 +152,7 @@ fi
 display_warning
 
 # Download the file
-STATE_URL="https://nodes.dusk.network/state/$state_number"
+STATE_URL="$STATE_BASE_URL/$state_number"
 echo "Downloading state $state_number from $STATE_URL..."
 
 if ! curl -f -so  /tmp/state.tar.gz -L "$STATE_URL"; then

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -232,7 +232,7 @@ ln -sf /opt/dusk/bin/rusk /usr/bin/rusk
 ln -sf /opt/dusk/bin/ruskquery /usr/bin/ruskquery
 ln -sf /opt/dusk/bin/ruskreset /usr/bin/ruskreset
 ln -sf /opt/dusk/bin/rusk-wallet /usr/bin/rusk-wallet
-if [ "$NETWORK" == "mainnet" ]; then
+if [[ "$NETWORK" == "mainnet" || "$NETWORK" == "testnet" ]]; then
     ln -sf /opt/dusk/bin/download_state.sh /usr/bin/download_state
 fi
 


### PR DESCRIPTION
## Summary
- add testnet support to `download_state`
- detect the installed network directly from `/opt/dusk/conf/rusk.toml`
- allow overriding network selection with `--network`
- install `download_state` for both mainnet and testnet nodes
- document the new behavior and override examples

## Why
`download_state` was hardcoded to mainnet state endpoints. This change keeps network selection tied to the installed Rusk config and makes the script usable for Nocturne testnet as well.