### PR TITLE
Update testnet Rusk to 1.7.0-rc.1

### DIFF
--- a/bin/ruskquery
+++ b/bin/ruskquery
@@ -3,7 +3,7 @@
 API_ENDPOINT="${API_ENDPOINT:-http://127.0.0.1:8080}"
 RUSK_VERSION="1.0.0"
 CONTENT_TYPE="application/json"
-INSTALLER_VERSION="v0.5.18"
+INSTALLER_VERSION="v0.5.19"
 
 show_help() {
     echo "Dusk Query Tool"

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -165,7 +165,7 @@ chown -R "$CURRENT_USER:dusk" "$CURRENT_HOME/.dusk"
 chmod -R 770 "$CURRENT_HOME/.dusk"
 
 # Download and extract installer files
-INSTALLER_URL="https://github.com/dusk-network/node-installer/archive/refs/tags/v0.5.19.tar.gz"
+INSTALLER_URL="https://github.com/dusk-network/node-installer/tarball/main"
 echo "Downloading installer package for additional scripts and configurations"
 curl -so /opt/dusk/installer/installer.tar.gz -L "$INSTALLER_URL"
 tar xf /opt/dusk/installer/installer.tar.gz --strip-components 1 --directory /opt/dusk/installer

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -18,6 +18,7 @@ VERSIONS=(
 # Default network and feature (Provisioner node)
 NETWORK="mainnet"
 FEATURE="default"
+TESTNET_CONSENSUS_SPIN_TIME="1779886800"
 
 # Parse command-line arguments to check for network or feature flags
 while [[ "$#" -gt 0 ]]; do
@@ -108,6 +109,11 @@ install_component() {
 configure_network() {
     local network=$1
     local prover_url
+    local service_file="/opt/dusk/services/rusk.service"
+
+    if [ -f "$service_file" ]; then
+        sed -i '/^Environment="RUSK_CONSENSUS_SPIN_TIME=/d' "$service_file"
+    fi
 
     case "$network" in
         mainnet)
@@ -122,6 +128,9 @@ configure_network() {
             mv /opt/dusk/conf/testnet.toml /opt/dusk/conf/rusk.toml
             rm /opt/dusk/conf/mainnet.genesis
             rm /opt/dusk/conf/mainnet.toml
+            if [ -f "$service_file" ]; then
+                sed -i "/^Environment=\"RUSK_RECOVERY_INPUT=/a Environment=\"RUSK_CONSENSUS_SPIN_TIME=$TESTNET_CONSENSUS_SPIN_TIME\"" "$service_file"
+            fi
             prover_url="https://testnet.provers.dusk.network"
             ;;
         *)

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -11,7 +11,7 @@ declare -A VERSIONS
 VERSIONS=(
     ["mainnet-rusk"]="1.6.1"
     ["mainnet-rusk-wallet"]="0.3.0"
-    ["testnet-rusk"]="1.7.0-rc.0"
+    ["testnet-rusk"]="1.7.0-rc.1"
     ["testnet-rusk-wallet"]="0.4.0"
 )
 
@@ -165,7 +165,7 @@ chown -R "$CURRENT_USER:dusk" "$CURRENT_HOME/.dusk"
 chmod -R 770 "$CURRENT_HOME/.dusk"
 
 # Download and extract installer files
-INSTALLER_URL="https://github.com/dusk-network/node-installer/tarball/main"
+INSTALLER_URL="https://github.com/dusk-network/node-installer/archive/refs/tags/v0.5.19.tar.gz"
 echo "Downloading installer package for additional scripts and configurations"
 curl -so /opt/dusk/installer/installer.tar.gz -L "$INSTALLER_URL"
 tar xf /opt/dusk/installer/installer.tar.gz --strip-components 1 --directory /opt/dusk/installer


### PR DESCRIPTION
## Summary
- set the testnet consensus spin time to `2026-05-27T13:00:00Z`
- update testnet Rusk from `1.7.0-rc.0` to `1.7.0-rc.1`
- update node-installer metadata to `v0.5.19`
- keep the installer URL reset to `main` after the release tag
