### PR TITLE
[codex] Restore devnet installer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </h1>
 
 <p align="center">
-  Official <img height="11" src="assets/dusk_circular_light.svg#gh-dark-mode-only"><img height="11" src="assets/dusk_circular_dark.svg#gh-light-mode-only"><a href="https://dusk.network/"> Dusk</a> Node installer, an easy-to-use installer for running a Dusk node on the Dusk mainnet and Nocturne testnet.
+  Official <img height="11" src="assets/dusk_circular_light.svg#gh-dark-mode-only"><img height="11" src="assets/dusk_circular_dark.svg#gh-light-mode-only"><a href="https://dusk.network/"> Dusk</a> Node installer, an easy-to-use installer for running a Dusk node on the Dusk mainnet, Nocturne testnet, and devnet.
 </p>
 
 <p align=center>
@@ -188,8 +188,8 @@ curl --proto '=https' --tlsv1.2 -sSfL https://raw.githubusercontent.com/dusk-net
 ### Networks
 
 By default, the installer runs the node for our mainnet. If you'd like to run a
-node for the Nocturne testnet, you can specify the network
-using the `--network` flag:
+node for the Nocturne testnet or devnet, you can specify the network using the
+`--network` flag:
 
 ```sh
 curl --proto '=https' --tlsv1.2 -sSfL https://github.com/dusk-network/node-installer/releases/latest/download/node-installer.sh | sudo bash -s -- --network testnet
@@ -199,6 +199,7 @@ Available network options:
 
 - `mainnet` (default)
 - `testnet`
+- `devnet`
 
 ### Features
 

--- a/conf/devnet.genesis
+++ b/conf/devnet.genesis
@@ -1,0 +1,65 @@
+# Dusk account
+
+[[moonlight_account]]
+address = 'o1YvWG34EBTwdskfZ7PCvWKRUWKzskVnhJNjZHdau6VaUNpgDxpoSsisK8KGF6FayUi8Lzn4taAvZcHGprQuPsqFGH66SEPDRCbTmKGVwFYX7bEp2rF4wekvoc4dS8ghnKf'
+balance = 699_000_000_000_000
+
+# Faucet wallet
+
+[[moonlight_account]]
+address = 'tUWiZxKqtVrP2uxqUAc593p1T5BW5MhPzjh8D2M32WFYpqjtBLbTAw6VhMN7BKYpaDjcy82GizsQ2pAgmguGTF9Bks3qNCDF3sDrpVWMXTJTWNGWgueHezvopEvUtZUs4mC'
+balance = 9_000_000_000_000_000
+
+# Faucet wallets (Fulvio)
+
+[[moonlight_account]]
+address = 'pR8NnsQ9Le2hyuEgx2fk4RuZTngkz9T7WfkdDKSJmnfRYMmkNUPhFYXNAeatxsYiixgqq4iKfSCVuo7NhFkLgrbn1VTTweLhPXocUQ4rfxMLRajebdCcPxp46ddSVMpu2Nf'
+balance = 75_000_000_000_000_000
+
+[[moonlight_account]]
+address = 'uzUXZAWqhJB1e2czyAPvUk1MaRP4t6CMEQHBGP4ixYem7kphpbW7yF3kkGyMD5agJ7oDH7yQPwcGxgsC1PxrRDAELXMR76eqLcU2ck2oWVYRgxc16yWuCQ8PzHZrs9Qi1Vu'
+balance = 75_000_000_000_000_000
+
+# 5 Dusk network provisioners
+
+[[stake]]
+address = 'pFPEcfxidLvwmFKRQoifrSyWmmVY9UDEThoRFvGXddXRLZ8hB7xfWDYQYwHhTvZvXeL1p5Ygcnsuuxm1X8nHFJH6tEgK3cS76squcFVFSejaKJGMorYZdTup5uscNq6eDU2'
+amount = 500_000_000_000_000
+
+[[stake]]
+address = 'rvXLHF8DBNwzZ63uSWPki3y7uNgGbdRCrKpouEP9N7awiGBDaP1uzyrtLBDtFbNgw8bPNjbyMsfAsNutZKnuX8JXzMiFvpW9vK4c2zmAmk3RygzwiFGCVJ9KSU7b4bgC1UT'
+amount = 500_000_000_000_000
+
+[[stake]]
+address = 'rdHa4H5p1rVtQyqD5AjDHyr1EGg7yVU1wynqQ9VRqU8Wp7kMcePsSk2tURGzRLnzS36CaKEadpfRGwa3ucvFH5MEGYvF1LAqSQQT3zE1Fx7wQzYsrvDpJ44bBa6dKxN6mTC'
+amount = 500_000_000_000_000
+
+[[stake]]
+address = '244Sywxj7PuMHpcPxemaXLcrY5rPgztra6H9Vz8cU1Ro5v23SxKTfVqr2yS7NXAXE1iq59ndn4aMZmYxuzu3Te3e9fokQKTUkYvFxYg2P2E8EEg1gWUbs3AFL2aNx62HQd7r'
+amount = 500_000_000_000_000
+
+[[stake]]
+address = '24bfNr8MDUo5xJBecmeGzXDEraax4Cmbnhjyyt5GaL1Vbe6H48ZSYTpmjRDcFRDFzgzuePAPUNcdGMnBzBQBk4zAMgBCtPsY27tBJtKmB1st6qcmpzRR4Er5imxrzvMRnfWc'
+amount = 500_000_000_000_000
+
+# Dusk network provisioners funds
+
+[[moonlight_account]]
+address = 'pFPEcfxidLvwmFKRQoifrSyWmmVY9UDEThoRFvGXddXRLZ8hB7xfWDYQYwHhTvZvXeL1p5Ygcnsuuxm1X8nHFJH6tEgK3cS76squcFVFSejaKJGMorYZdTup5uscNq6eDU2'
+balance = 100_000_000_000
+
+[[moonlight_account]]
+address = 'rvXLHF8DBNwzZ63uSWPki3y7uNgGbdRCrKpouEP9N7awiGBDaP1uzyrtLBDtFbNgw8bPNjbyMsfAsNutZKnuX8JXzMiFvpW9vK4c2zmAmk3RygzwiFGCVJ9KSU7b4bgC1UT'
+balance = 100_000_000_000
+
+[[moonlight_account]]
+address = 'rdHa4H5p1rVtQyqD5AjDHyr1EGg7yVU1wynqQ9VRqU8Wp7kMcePsSk2tURGzRLnzS36CaKEadpfRGwa3ucvFH5MEGYvF1LAqSQQT3zE1Fx7wQzYsrvDpJ44bBa6dKxN6mTC'
+balance = 100_000_000_000
+
+[[moonlight_account]]
+address = '244Sywxj7PuMHpcPxemaXLcrY5rPgztra6H9Vz8cU1Ro5v23SxKTfVqr2yS7NXAXE1iq59ndn4aMZmYxuzu3Te3e9fokQKTUkYvFxYg2P2E8EEg1gWUbs3AFL2aNx62HQd7r'
+balance = 100_000_000_000
+
+[[moonlight_account]]
+address = '24bfNr8MDUo5xJBecmeGzXDEraax4Cmbnhjyyt5GaL1Vbe6H48ZSYTpmjRDcFRDFzgzuePAPUNcdGMnBzBQBk4zAMgBCtPsY27tBJtKmB1st6qcmpzRR4Er5imxrzvMRnfWc'
+balance = 100_000_000_000

--- a/conf/devnet.toml
+++ b/conf/devnet.toml
@@ -1,0 +1,57 @@
+# log_type = 'coloured' (default)
+log_type = 'json'
+
+# log_level = 'info' (default)
+# log_filter = 'dusk_consensus=debug,node=debug,kadcast=debug'
+
+[chain]
+genesis_timestamp = '2026-05-27T14:14:14Z'
+db_path = '/opt/dusk/rusk'
+consensus_keys_path = '/opt/dusk/conf/consensus.keys'
+min_gas_limit = 150_000
+
+[vm]
+generation_timeout = '3s'
+
+[databroker]
+max_inv_entries = 100
+max_ongoing_requests = 1000
+
+[mempool]
+max_queue_size = 5000
+max_mempool_txn_count = 10000
+idle_interval = '5m'
+mempool_expiry = '30m'
+mempool_download_redundancy = 5
+
+[kadcast]
+kadcast_id = 0x3
+public_address = 'N/A'
+listen_address = 'N/A'
+bootstrapping_nodes = ['159.69.52.221:9000', '159.69.115.19:9000']
+auto_propagate = false
+channel_size = 10000
+recursive_discovery = true
+
+[kadcast.bucket]
+node_ttl = '120s'
+node_evict_after = '15s'
+bucket_ttl = '10m'
+min_peers = 20
+
+[kadcast.network]
+udp_recv_buffer_size = 50_000_000
+# udp_send_backoff_timeout = '50us'
+udp_send_retry_interval = '5ms'
+udp_send_retry_count = 3
+blocklist_refresh_interval = '10s'
+
+[kadcast.fec.encoder]
+min_repair_packets_per_block = 5
+mtu = 1300
+fec_redundancy = 0.15
+
+[kadcast.fec.decoder]
+cache_ttl = '1m'
+cache_prune_every = '30s'
+max_udp_len = 2097152

--- a/node-installer.sh
+++ b/node-installer.sh
@@ -13,6 +13,8 @@ VERSIONS=(
     ["mainnet-rusk-wallet"]="0.3.0"
     ["testnet-rusk"]="1.7.0-rc.1"
     ["testnet-rusk-wallet"]="0.4.0"
+    ["devnet-rusk"]="1.7.0-rc.1"
+    ["devnet-rusk-wallet"]="0.4.0"
 )
 
 # Default network and feature (Provisioner node)
@@ -33,7 +35,7 @@ while [[ "$#" -gt 0 ]]; do
             ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--network mainnet|testnet] [--feature default|archive]"
+            echo "Usage: $0 [--network mainnet|testnet|devnet] [--feature default|archive]"
             exit 1
             ;;
     esac
@@ -41,11 +43,11 @@ done
 
 # Validate passed network
 case "$NETWORK" in
-    mainnet|testnet)
+    mainnet|testnet|devnet)
         echo "Selected network: $NETWORK"
         ;;
     *)
-        echo "Error: Unknown network $NETWORK. Use 'mainnet' or 'testnet'."
+        echo "Error: Unknown network $NETWORK. Use 'mainnet', 'testnet', or 'devnet'."
         exit 1
         ;;
 esac
@@ -121,6 +123,8 @@ configure_network() {
             mv /opt/dusk/conf/mainnet.toml /opt/dusk/conf/rusk.toml
             rm /opt/dusk/conf/testnet.genesis
             rm /opt/dusk/conf/testnet.toml
+            rm /opt/dusk/conf/devnet.genesis
+            rm /opt/dusk/conf/devnet.toml
             prover_url="https://provers.dusk.network"
             ;;
         testnet)
@@ -128,10 +132,21 @@ configure_network() {
             mv /opt/dusk/conf/testnet.toml /opt/dusk/conf/rusk.toml
             rm /opt/dusk/conf/mainnet.genesis
             rm /opt/dusk/conf/mainnet.toml
+            rm /opt/dusk/conf/devnet.genesis
+            rm /opt/dusk/conf/devnet.toml
             if [ -f "$service_file" ]; then
                 sed -i "/^Environment=\"RUSK_RECOVERY_INPUT=/a Environment=\"RUSK_CONSENSUS_SPIN_TIME=$TESTNET_CONSENSUS_SPIN_TIME\"" "$service_file"
             fi
             prover_url="https://testnet.provers.dusk.network"
+            ;;
+        devnet)
+            mv /opt/dusk/conf/devnet.genesis /opt/dusk/conf/genesis.toml
+            mv /opt/dusk/conf/devnet.toml /opt/dusk/conf/rusk.toml
+            rm /opt/dusk/conf/mainnet.genesis
+            rm /opt/dusk/conf/mainnet.toml
+            rm /opt/dusk/conf/testnet.genesis
+            rm /opt/dusk/conf/testnet.toml
+            prover_url="https://devnet.provers.dusk.network"
             ;;
         *)
             echo "Unknown network: $network. Defaulting to mainnet."


### PR DESCRIPTION
## Summary
- restore devnet as a valid installer network using the same Rusk and wallet versions as testnet
- add devnet genesis and rusk config from the active devnet setup
- document devnet as an available network option

## Validation
- bash -n node-installer.sh
- git diff --cached --check
- curl -fLIs https://devnet.nodes.dusk.network/state/list (confirmed devnet fast-sync endpoint is not available, so download_state remains mainnet/testnet only)